### PR TITLE
docs(schematics): typo, action should be effect

### DIFF
--- a/docs/schematics/effect.md
+++ b/docs/schematics/effect.md
@@ -50,7 +50,7 @@ When used with the `--module` option, it registers an effect within the `Angular
   - Type: `boolean`
   - Default: `false`
 
-Generate a spec file alongside the action file.
+Generate a spec file alongside the effect file.
 
 - `--spec`
   - Type: `boolean`

--- a/docs/schematics/effect.md
+++ b/docs/schematics/effect.md
@@ -50,7 +50,7 @@ When used with the `--module` option, it registers an effect within the `Angular
   - Type: `boolean`
   - Default: `false`
 
-Generate a spec file alongside the effect file.
+Generate a spec file alongside the action file.
 
 - `--spec`
   - Type: `boolean`

--- a/projects/ngrx.io/content/guide/schematics/effect.md
+++ b/projects/ngrx.io/content/guide/schematics/effect.md
@@ -65,7 +65,7 @@ Specifies if effect has api success and failure actions wired up.
   - Type: `boolean`
   - Default: `false`
 
-Generate a spec file alongside the action file.
+Generate a spec file alongside the effect file.
 
 - `--spec`
   - Type: `boolean`


### PR DESCRIPTION
Correct typo reported by @timdeschryver
Issue #2161

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Docs say 'Generate a spec file alongside the action file.'
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #
#2161

## What is the new behavior?
Docs say 'Generate a spec file alongside the effect file.'

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
